### PR TITLE
Limitations for registration

### DIFF
--- a/resources/oti/migrations/001-create-tables.up.sql
+++ b/resources/oti/migrations/001-create-tables.up.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS exam_session (
   start_time TIME NOT NULL,
   end_time TIME NOT NULL,
   location_info TEXT NOT NULL,
+  max_participants NUMERIC DEFAULT 40,
   exam_id BIGINT REFERENCES exam (id) NOT NULL
 );
 --;;
@@ -34,7 +35,8 @@ CREATE TABLE IF NOT EXISTS registration (
   id BIGSERIAL PRIMARY KEY,
   state registration_state NOT NULL,
   exam_session_id BIGINT REFERENCES exam_session (id) NOT NULL,
-  participant_id BIGINT REFERENCES participant (id) NOT NULL
+  participant_id BIGINT REFERENCES participant (id) NOT NULL,
+  CONSTRAINT one_participation_per_session_constraint UNIQUE (exam_session_id, participant_id)
 );
 --;;
 CREATE TYPE payment_state AS ENUM ('OK', 'UNPAID', 'ERROR');

--- a/resources/oti/migrations/003-session-participant-limit-trigger.down.sql
+++ b/resources/oti/migrations/003-session-participant-limit-trigger.down.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS participant_limit_trigger ON registration CASCADE;

--- a/resources/oti/migrations/003-session-participant-limit-trigger.up.sql
+++ b/resources/oti/migrations/003-session-participant-limit-trigger.up.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION error_if_exceeds_participant_limit() RETURNS TRIGGER AS $$
+DECLARE
+  current_registrations NUMERIC := (
+    SELECT count(*) FROM registration
+    WHERE exam_session_id = NEW.exam_session_id
+  );
+  session_limit NUMERIC := (
+    SELECT max_participants FROM exam_session WHERE id = NEW.exam_session_id
+  );
+BEGIN
+  IF current_registrations < session_limit THEN
+    RETURN NEW;
+  ELSE
+    RAISE EXCEPTION 'max_participants of exam_session exceeded.';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+--;;
+CREATE TRIGGER participant_limit_trigger
+  BEFORE INSERT
+  ON registration
+  FOR EACH ROW
+  EXECUTE PROCEDURE error_if_exceeds_participant_limit();


### PR DESCRIPTION
Participant may only register once per session and registrations are
accepted only up until defined max_participations of the session
(defaults to 40)