### PR TITLE
Feature/oti 24 kayttoliittymien kaksikielisyys

### DIFF
--- a/dev/resources/dev.edn
+++ b/dev/resources/dev.edn
@@ -10,4 +10,6 @@
   :authentication {:opintopolku-login-uri "https://itest-virkailija.oph.ware.fi/cas/login?service="
                    :opintopolku-logout-uri  "https://itest-virkailija.oph.ware.fi/cas/logout?service="
                    :oti-login-success-uri "http://localhost:3000/oti/auth/cas"}
-  :cas {:virkailija-lb-uri "https://itest-virkailija.oph.ware.fi"}}}
+  :cas {:virkailija-lb-uri "https://itest-virkailija.oph.ware.fi"}
+  :localisation {:service-base-uri "https://itest-virkailija.oph.ware.fi/lokalisointi/cxf/rest/v1/localisation"
+                 :default-parameters {:category "oti"}}}}

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                  [cheshire "5.6.3"]
                  [com.taoensso/timbre "4.7.4"]
                  [org.clojars.mpenttila/yesql "0.6.1"]
+                 [camel-snake-kebab "0.4.0"]
 
                  ;; Frontend
                  [org.clojure/clojurescript "1.9.229"]

--- a/resources/oti/public/css/main.css
+++ b/resources/oti/public/css/main.css
@@ -1,4 +1,8 @@
 @charset "UTF-8";
+html,
+body {
+  height: 100%;
+}
 .clearfix,
 .exam-session-form,
 .registration .section,
@@ -679,7 +683,7 @@ input[type="button"]:not(:first-child) {
   padding-top: 10px;
 }
 #header {
-  margin-top: 20px;
+  padding-top: 20px;
   max-width: 940px !important;
   margin-left: auto;
   margin-right: auto;

--- a/resources/oti/public/css/main.css
+++ b/resources/oti/public/css/main.css
@@ -472,6 +472,56 @@ http://nicolasgallagher.com/micro-clearfix-hack/
 .registrations table td {
   width: 25%;
 }
+@keyframes loader {
+  0% {
+    color: #1b1b1b;
+  }
+  50% {
+    color: #00a651;
+  }
+  100% {
+    color: #1b1b1b;
+  }
+}
+@keyframes loader-opacity {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.loader {
+  opacity: 0;
+  position: absolute;
+  z-index: 9000;
+  background-color: #fff;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-animation-name: loader, loader-opacity;
+  -moz-animation-name: loader, loader-opacity;
+  -o-animation-name: loader, loader-opacity;
+  animation-name: loader, loader-opacity;
+  -webkit-animation-fill-mode: both, forwards;
+  -moz-animation-fill-mode: both, forwards;
+  -o-animation-fill-mode: both, forwards;
+  animation-fill-mode: both, forwards;
+  -webkit-animation-duration: 2s, 2s;
+  -moz-animation-duration: 2s, 2s;
+  -o-animation-duration: 2s, 2s;
+  animation-duration: 2s, 2s;
+  -webkit-animation-delay: 0s, 2s;
+  -moz-animation-delay: 0s, 2s;
+  -o-animation-delay: 0s, 2s;
+  animation-delay: 0s, 2s;
+  -webkit-animation-iteration-count: infinite, 1;
+  -moz-animation-iteration-count: infinite, 1;
+  -o-animation-iteration-count: infinite, 1;
+  animation-iteration-count: infinite, 1;
+}
 .left {
   float: left;
 }

--- a/resources/oti/system.edn
+++ b/resources/oti/system.edn
@@ -5,7 +5,8 @@
   :ragtime duct.component.ragtime/ragtime
   :ldap oti.component.ldap/ldap
   :cas oti.component.cas/cas-config
-  :api-client oti.component.api-client/api-client}
+  :api-client oti.component.api-client/api-client
+  :localisation oti.component.localisation/localisation}
  :endpoints
  {:status oti.endpoint.status/status-endpoint
   :frontend oti.endpoint.frontend/frontend-endpoint
@@ -19,8 +20,10 @@
   :status []
   :auth [:authentication :cas :ldap]
   :virkailija [:db :api-client]
-  :participant [:db :payments :api-client]
+  :participant [:db :payments :api-client :localisation]
   :api-client [:cas]}
+  :participant [:db :payments :localisation]
+  :localisation []}
  :config
  {:app
   {:middleware

--- a/src/clj/oti/component/localisation.clj
+++ b/src/clj/oti/component/localisation.clj
@@ -7,8 +7,8 @@
 
 (defprotocol LocalisationQuery
   "Localisation query protocol"
-  (by-lang [this lang] "Query translation by language")
-  (refresh [this] "Refresh all translations by fetching from the external localisation service"))
+  (translations-by-lang [this lang] "Query translation by language")
+  (refresh-translations [this] "Refresh all translations by fetching from the external localisation service"))
 
 (defn- parse-translations [response-body]
   (into {} (->> response-body
@@ -32,11 +32,11 @@
   (stop [this] (assoc this :translations (atom {})))
 
   LocalisationQuery
-  (by-lang [this lang]
+  (translations-by-lang [this lang]
     (->> @(:translations this)
          (map (fn [[k v]] [k ((keyword lang) v)]))
          (into {})))
-  (refresh [this]
+  (refresh-translations [this]
     (when-let [new-translations (fetch-translations (:service-base-uri config)
                                                     (:default-parameters config))]
       (reset! (:translations this) new-translations))))

--- a/src/clj/oti/component/localisation.clj
+++ b/src/clj/oti/component/localisation.clj
@@ -1,0 +1,45 @@
+(ns oti.component.localisation
+  (:require [com.stuartsierra.component :as component]
+            [org.httpkit.client :as http]
+            [cheshire.core :refer [parse-string]]
+            [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [taoensso.timbre :refer [debug error]]))
+
+(defprotocol LocalisationQuery
+  "Localisation query protocol"
+  (by-lang [this lang] "Query translation by language")
+  (refresh [this] "Refresh all translations by fetching from the external localisation service"))
+
+(defn- parse-translations [response-body]
+  (into {} (->> response-body
+                (group-by :key)
+                (map (fn [[key translation]]
+                       {key (reduce (fn [ts t]
+                                      (assoc ts (->kebab-case-keyword (:locale t)) (:value t))) {} translation)})))))
+
+(defn- fetch-translations [uri parameters]
+  (debug "Fetching translations from:" uri "with query parameters:" parameters)
+  (let [{:keys [headers status error body]} @(http/get uri {:query-params parameters})]
+    (try
+      (parse-translations (parse-string body ->kebab-case-keyword))
+      (catch Exception e
+        (error "Could not parse response:" (.getMessage e))))))
+
+(defrecord Localisation [config]
+  component/Lifecycle
+  (start [this] (assoc this :translations (atom (fetch-translations (:service-base-uri config)
+                                                                    (:default-parameters config)))))
+  (stop [this] (assoc this :translations (atom {})))
+
+  LocalisationQuery
+  (by-lang [this lang]
+    (->> @(:translations this)
+         (map (fn [[k v]] [k ((keyword lang) v)]))
+         (into {})))
+  (refresh [this]
+    (when-let [new-translations (fetch-translations (:service-base-uri config)
+                                                    (:default-parameters config))]
+      (reset! (:translations this) new-translations))))
+
+(defn localisation [config]
+  (->Localisation config))

--- a/src/clj/oti/endpoint/participant.clj
+++ b/src/clj/oti/endpoint/participant.clj
@@ -99,10 +99,10 @@
       (GET "/translations" [lang]
         (if (str/blank? lang)
           {:status 400 :body {:error "Missing lang parameter"}}
-          (response (localisation/by-lang localisation lang))))
+          (response (localisation/translations-by-lang localisation lang))))
       (GET "/translations/refresh" []
-        (if (localisation/refresh localisation)
-          (response {:message "ok"})
+        (if-let [new-translations (localisation/refresh-translations localisation)]
+          (response new-translations)
           {:status 500 :body {:error "Refreshing translations failed"}}))
       ;; FIXME: This is a dummy route
       (GET "/authenticate" [callback]

--- a/src/clj/oti/endpoint/participant.clj
+++ b/src/clj/oti/endpoint/participant.clj
@@ -2,25 +2,18 @@
   (:require [compojure.core :refer :all]
             [ring.util.response :refer [resource-response content-type redirect response]]
             [clojure.spec :as s]
-            [oti.boundary.db-access :as dba]
-            [oti.spec :as os]
             [clojure.string :as str]
+            [oti.boundary.db-access :as dba]
+            [oti.component.localisation :as localisation]
+            [oti.spec :as os]
             [oti.routing :as routing]
             [oti.util.coercion :as c]
             [ring.util.response :as resp]
             [cognitect.transit :as transit]
             [clojure.java.io :as io]
-            [taoensso.timbre :refer [error]]
+            [taoensso.timbre :refer [error info]]
             [meta-merge.core :refer [meta-merge]]
-            [oti.boundary.api-client-access :as api]))
-
-(def translations
-  {"Ilmoittautuminen" {:fi "Ilmoittautuminen" :sv "Anmälning"}
-   "switch-language" {:fi "Pä svenska" :sv "Suomeksi"}
-   "registration-title" {:fi "Opetushallinnon tutkintoon ilmoittautuminen"
-                         :sv "Anmälning till examen i undervisningsförvaltning"}
-   "fi" {:fi "Suomi" :sv "Finska"}
-   "sv" {:fi "Ruotsi" :sv "Svenska"}})
+            [oti.boundary.api-client-access :as api])) 
 
 (def check-digits {0  0 16 "H"
                    1  1 17 "J"
@@ -96,18 +89,21 @@
               (registration-response :failure "Ilmoittautumisessa tapahtui odottamaton virhe" lang session))))))
     (registration-response :failure "Ilmoittautumistiedot olivat virheelliset" :fi session)))
 
-(defn participant-endpoint [{:keys [db payments api-client] :as config}]
+(defn participant-endpoint [{:keys [db payments api-client localisatation] :as config}]
   (routes
     (GET "/oti/abort" []
       (-> (resp/redirect "/oti/ilmoittaudu")
           (assoc :session {})))
     (context routing/participant-api-root []
+      ;; TODO: Maybe relocate translation endpoints to a localisation endpoint?
       (GET "/translations" [lang]
         (if (str/blank? lang)
           {:status 400 :body {:error "Missing lang parameter"}}
-          (response (->> translations
-                         (map (fn [[k v]] [k ((keyword lang) v)]))
-                         (into {})))))
+          (response (localisation/by-lang localisation lang))))
+      (GET "/translations/refresh" []
+        (if (localisation/refresh localisation)
+          (response {:message "ok"})
+          {:status 500 :body {:error "Refreshing translations failed"}}))
       ;; FIXME: This is a dummy route
       (GET "/authenticate" [callback]
         (if-not (str/blank? callback)

--- a/src/cljs/oti/ui/db.cljs
+++ b/src/cljs/oti/ui/db.cljs
@@ -5,4 +5,5 @@
    :language nil
    :translations {}
    :exam-sessions []
-   :flash-message {}})
+   :flash-message {}
+   :loading false})

--- a/src/cljs/oti/ui/registration/handlers.cljs
+++ b/src/cljs/oti/ui/registration/handlers.cljs
@@ -12,7 +12,8 @@
                   :params          {:lang (name lang)}
                   :response-format (ajax/transit-response-format)
                   :on-success      [:store-response-to-db :translations]
-                  :on-failure      [:bad-response]}}))
+                  :on-failure      [:bad-response]}
+     :loader true}))
 
 (re-frame/reg-event-fx
   :load-participant-data

--- a/src/cljs/oti/ui/registration/views/main.cljs
+++ b/src/cljs/oti/ui/registration/views/main.cljs
@@ -5,6 +5,7 @@
             [oti.ui.registration.views.registration :as rv]
             [oti.ui.registration.views.registration-result :as rrv]
             [oti.ui.exam-sessions.utils :as utils]
+            [oti.ui.views.common :refer [loader]]
             [re-frame.core :as re-frame]
             [oti.routing :as routing]
             [oti.ui.i18n :refer [t]]))
@@ -27,9 +28,12 @@
   (re-frame/dispatch [:load-participant-data])
   (let [flash-message (re-frame/subscribe [:flash-message])
         current-language (re-frame/subscribe [:language])
-        participant-data (re-frame/subscribe [:participant-data])]
+        participant-data (re-frame/subscribe [:participant-data])
+        loading? (re-frame/subscribe [:loading?])]
     (fn []
       [:div
+       (when @loading?
+         (loader))
        [:div#header
         [:img {:src (routing/img "opetushallitus.gif")}]
         [:p (t "registration-title")]

--- a/src/cljs/oti/ui/subs.cljs
+++ b/src/cljs/oti/ui/subs.cljs
@@ -2,7 +2,7 @@
     (:require-macros [reagent.ratom :refer [reaction]])
     (:require [re-frame.core :as re-frame]))
 
-(def interesting-keys [:user :active-panel :flash-message :active-panel-data])
+(def interesting-keys [:user :active-panel :flash-message :active-panel-data :loading?])
 
 (doseq [key interesting-keys]
   (re-frame/reg-sub

--- a/src/cljs/oti/ui/views/common.cljs
+++ b/src/cljs/oti/ui/views/common.cljs
@@ -1,0 +1,5 @@
+(ns oti.ui.views.common
+  (:require [oti.ui.i18n :refer [t]]))
+
+(defn loader []
+  [:div.loader (t "loading")])

--- a/src/cljs/oti/ui/views/virkailija_main.cljs
+++ b/src/cljs/oti/ui/views/virkailija_main.cljs
@@ -4,6 +4,7 @@
             [oti.ui.exam-sessions.exam-session :refer [new-exam-session edit-exam-session]]
             [oti.ui.exam-registrations.registration-list :as registration-list]
             [oti.ui.routes :refer [virkailija-routes]]
+            [oti.ui.views.common :refer [loader]]
             [oti.routing :as routing]))
 
 (defmulti panels identity)
@@ -38,9 +39,12 @@
   (let [active-panel (re-frame/subscribe [:active-panel])
         active-panel-data (re-frame/subscribe [:active-panel-data])
         user (re-frame/subscribe [:user])
-        flash-message (re-frame/subscribe [:flash-message])]
+        flash-message (re-frame/subscribe [:flash-message])
+        loading? (re-frame/subscribe [:loading?])]
     (fn []
       [:div
+       (when loading?
+         (loader))
        [:div#header
         [:img {:src (routing/img "opetushallitus.gif")}]
         [:p "Opetushallinnon tutkintorekisteri"]

--- a/src/less/_loader.less
+++ b/src/less/_loader.less
@@ -1,0 +1,42 @@
+@keyframes loader {
+  0% {color: @default-font-color;}
+  50% {color: @oph-green;}
+  100% {color: @default-font-color;}
+}
+
+@keyframes loader-opacity {
+  from {opacity: 0}
+  to {opacity: 1}
+}
+
+.loader {
+  opacity: 0;
+  position: absolute;
+  z-index: 9000;
+  background-color: #fff;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-animation-name: loader, loader-opacity;
+  -moz-animation-name: loader, loader-opacity;
+  -o-animation-name: loader, loader-opacity;
+  animation-name: loader, loader-opacity;
+  -webkit-animation-fill-mode: both, forwards;
+  -moz-animation-fill-mode: both, forwards;
+  -o-animation-fill-mode: both, forwards;
+  animation-fill-mode: both, forwards;
+  -webkit-animation-duration: 2s, 2s;
+  -moz-animation-duration: 2s, 2s;
+  -o-animation-duration: 2s, 2s;
+  animation-duration: 2s, 2s;
+  -webkit-animation-delay: 0s, 2s;
+  -moz-animation-delay: 0s, 2s;
+  -o-animation-delay: 0s, 2s;
+  animation-delay: 0s, 2s;
+  -webkit-animation-iteration-count: infinite, 1;
+  -moz-animation-iteration-count: infinite, 1;
+  -o-animation-iteration-count: infinite, 1;
+  animation-iteration-count: infinite, 1;
+}

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -12,6 +12,7 @@
 @import "_pikaday";
 @import "_icons";
 @import "_registrations";
+@import "_loader";
 
 .left {
   float: left;

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -1,3 +1,7 @@
+html, body {
+  height: 100%;
+}
+
 .clearfix{
   zoom:1;
   &:before, &:after{ content:""; display:table; }
@@ -141,7 +145,7 @@ input[type="button"] {
 }
 
 #header{
-  margin-top: 20px;
+  padding-top: 20px;
   max-width: 940px !important;
   margin-left: auto;
   margin-right: auto;

--- a/test/oti/component/localisation_test.clj
+++ b/test/oti/component/localisation_test.clj
@@ -1,0 +1,7 @@
+(ns oti.component.localisation-test
+  (:require [clojure.test :refer :all]
+            [oti.component.localisation :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, even if I don't fail."
+    (is (= 1 1))))


### PR DESCRIPTION
Does solve issue when translation is somehow now found yet. Uses location service for loading translations for the whole project at startup. Adds optional loader functionality to re-frame fx-handlers using key :loader (true/false). Looks silly though.